### PR TITLE
Add windows variant of hello-world

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -1,6 +1,8 @@
+$ErrorActionPreference = "Stop";
 docker build -f .\windows\Dockerfile.build -t builder .\windows\.
 docker create --name out builder
 docker cp out:hello.exe .\windows\.
 docker rm out
 docker build -t hello-world:windows .\windows\.
+Remove-Item -Force .\windows\hello.exe
 docker run hello-world:windows

--- a/update.ps1
+++ b/update.ps1
@@ -1,0 +1,6 @@
+docker build -f .\windows\Dockerfile.build -t builder .\windows\.
+docker create --name out builder
+docker cp out:hello.exe .\windows\.
+docker rm out
+docker build -t hello-world:windows .\windows\.
+docker run hello-world:windows

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -1,0 +1,3 @@
+FROM microsoft/nanoserver
+COPY hello.exe /
+CMD ["hello.exe"]

--- a/windows/Dockerfile.build
+++ b/windows/Dockerfile.build
@@ -2,7 +2,6 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-RUN Install-WindowsFeature NET-Framework-45-Core
 RUN Invoke-WebRequest "https://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe" \
 		-OutFile visualcppbuildtools_full.exe -UseBasicParsing ; \
 	Start-Process -FilePath 'visualcppbuildtools_full.exe' -ArgumentList '/quiet', '/NoRestart' -Wait ; \
@@ -15,4 +14,4 @@ RUN pushd 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC' ; \
 	popd
 
 ADD hello.c .
-RUN cl /D_WIN32_WINNT=0x0A00 /D_WINVER=0x0A00 hello.c
+RUN cl hello.c

--- a/windows/Dockerfile.build
+++ b/windows/Dockerfile.build
@@ -1,0 +1,18 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+RUN Install-WindowsFeature NET-Framework-45-Core
+RUN Invoke-WebRequest "https://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe" \
+		-OutFile visualcppbuildtools_full.exe -UseBasicParsing ; \
+	Start-Process -FilePath 'visualcppbuildtools_full.exe' -ArgumentList '/quiet', '/NoRestart' -Wait ; \
+	Remove-Item .\visualcppbuildtools_full.exe
+
+RUN [Environment]::SetEnvironmentVariable('PATH', ${Env:ProgramFiles(x86)} + '\Microsoft Visual Studio 14.0\VC\bin\amd64;' + ${Env:ProgramFiles(x86)} + '\Windows Kits\10\bin\x64;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
+
+RUN pushd 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC' ; \
+	cmd /c 'vcvarsall.bat amd64&set' | foreach { if ($_ -match '=') { $v = $_.split('='); setx /M $v[0] $v[1] } } ; \
+	popd
+
+ADD hello.c .
+RUN cl /D_WIN32_WINNT=0x0A00 /D_WINVER=0x0A00 hello.c

--- a/windows/Dockerfile.build
+++ b/windows/Dockerfile.build
@@ -2,14 +2,19 @@ FROM microsoft/windowsservercore
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-RUN Invoke-WebRequest "https://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe" \
+ENV VISUAL_CPP_BUILD_TOOLS_URL "https://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe"
+
+RUN Write-Host ('Downloading {0}...' -f $Env:VISUAL_CPP_BUILD_TOOLS_URL); \
+	Invoke-WebRequest $Env:VISUAL_CPP_BUILD_TOOLS_URL \
 		-OutFile visualcppbuildtools_full.exe -UseBasicParsing ; \
+	Write-Host 'Installing Visual C++ Build Tools (can take a while)...'; \
 	Start-Process -FilePath 'visualcppbuildtools_full.exe' -ArgumentList '/quiet', '/NoRestart' -Wait ; \
 	Remove-Item .\visualcppbuildtools_full.exe
 
 RUN [Environment]::SetEnvironmentVariable('PATH', ${Env:ProgramFiles(x86)} + '\Microsoft Visual Studio 14.0\VC\bin\amd64;' + ${Env:ProgramFiles(x86)} + '\Windows Kits\10\bin\x64;' + $env:PATH, [EnvironmentVariableTarget]::Machine);
 
-RUN pushd 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC' ; \
+RUN Write-Host 'Configuring environment'; \
+	pushd 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC' ; \
 	cmd /c 'vcvarsall.bat amd64&set' | foreach { if ($_ -match '=') { $v = $_.split('='); setx /M $v[0] $v[1] } } ; \
 	popd
 

--- a/windows/hello.c
+++ b/windows/hello.c
@@ -1,0 +1,31 @@
+#include<stdio.h>
+
+const char message[] =
+	"\n"
+	"Hello from Docker!\n"
+	"This message shows that your installation appears to be working correctly.\n"
+	"\n"
+	"To generate this message, Docker took the following steps:\n"
+	" 1. The Docker client contacted the Docker daemon.\n"
+	" 2. The Docker daemon pulled the \"hello-world\" image from the Docker Hub.\n"
+	" 3. The Docker daemon created a new container from that image which runs the\n"
+	"    executable that produces the output you are currently reading.\n"
+	" 4. The Docker daemon streamed that output to the Docker client, which sent it\n"
+	"    to your terminal.\n"
+	"\n"
+	"To try something more ambitious, you can run an Nanoserver container with:\n"
+	" > docker run -it microsoft/nanoserver powershell\n"
+	"\n"
+	"Share images, automate workflows, and more with a free Docker Hub account:\n"
+	" https://hub.docker.com\n"
+	"\n"
+	"For more examples and ideas, visit:\n"
+	" https://docs.docker.com/engine/userguide/\n"
+	"\n";
+
+
+int main()
+{
+	printf(message);
+	return 0;
+}


### PR DESCRIPTION
@tianon This is not as minimal as your images for Linux, but it's still pretty small. I can try and twiddle compiler options to see if a smaller binary is possible.

More importantly, I'd like to see if we could work towards making this the first true multi-arch image, and use the manifest-list tool or similar: https://github.com/estesp/manifest-tool

The goal is that one can do `docker run hello-world` and the right image is pulled on both Windows and Linux without any tag required.

Note that the `microsoft/nanoserver` will work appropriately here: It can run on both Nanoserver and Windowsservercore (and on Windows 10 in Hyper-V mode), and in both hyper-v and windows container mode.

Let me know what you think.

cc @taylorb-microsoft @PatrickLang @toli @yosifkit @StefanScherer
