### PR TITLE
Add Windows 1809 support

### DIFF
--- a/Dockerfile-windows.template
+++ b/Dockerfile-windows.template
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:XXX
+FROM mcr.microsoft.com/windows/nanoserver:XXX
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,17 @@ $(C_TARGETS): hello.c
 	$(CC) $(CFLAGS) -o '$@' -D DOCKER_IMAGE='"$(notdir $(@D))"' -D DOCKER_GREETING="\"$$(cat 'greetings/$(notdir $(@D)).txt')\"" -D DOCKER_ARCH='"$(TARGET_ARCH)"' '$<'
 	$(STRIP) -R .comment -s '$@'
 	@if [ '$(TARGET_ARCH)' = 'amd64' ]; then \
-		for winVariant in nanoserver-sac2016 nanoserver-1709 nanoserver-1803; do \
+		for winVariant in \
+			nanoserver-sac2016 \
+			nanoserver-1709 \
+			nanoserver-1803 \
+			nanoserver-1809 \
+		; do \
 			mkdir -p "$(@D)/$$winVariant"; \
 			'$@' | sed \
 				-e 's/[(]$(TARGET_ARCH)[)]/(windows-$(TARGET_ARCH), '"$$winVariant"')/g' \
 				-e 's/an Ubuntu container/a Windows Server container/g' \
-				-e 's!ubuntu bash!microsoft/windowsservercore powershell!g' \
+				-e 's!ubuntu bash!mcr.microsoft.com/windows/servercore powershell!g' \
 				-e 's![$$] docker!PS C:\\> docker!g' \
 				> "$(@D)/$$winVariant/hello.txt"; \
 		done; \

--- a/amd64/hello-seattle/nanoserver-1709/Dockerfile
+++ b/amd64/hello-seattle/nanoserver-1709/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:1709
+FROM mcr.microsoft.com/windows/nanoserver:1709
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hello-seattle/nanoserver-1709/hello.txt
+++ b/amd64/hello-seattle/nanoserver-1709/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it microsoft/windowsservercore powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/amd64/hello-seattle/nanoserver-1803/Dockerfile
+++ b/amd64/hello-seattle/nanoserver-1803/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:1803
+FROM mcr.microsoft.com/windows/nanoserver:1803
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hello-seattle/nanoserver-1803/hello.txt
+++ b/amd64/hello-seattle/nanoserver-1803/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it microsoft/windowsservercore powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/amd64/hello-seattle/nanoserver-1809/Dockerfile
+++ b/amd64/hello-seattle/nanoserver-1809/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/windows/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:1809
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hello-seattle/nanoserver-1809/hello.txt
+++ b/amd64/hello-seattle/nanoserver-1809/hello.txt
@@ -1,11 +1,11 @@
 
-Hello from Docker!
+Hello from DockerCon 2016 (Seattle)!
 This message shows that your installation appears to be working correctly.
 
 To generate this message, Docker took the following steps:
  1. The Docker client contacted the Docker daemon.
- 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-    (windows-amd64, nanoserver-sac2016)
+ 2. The Docker daemon pulled the "hello-seattle" image from the Docker Hub.
+    (windows-amd64, nanoserver-1809)
  3. The Docker daemon created a new container from that image which runs the
     executable that produces the output you are currently reading.
  4. The Docker daemon streamed that output to the Docker client, which sent it

--- a/amd64/hello-seattle/nanoserver-sac2016/hello.txt
+++ b/amd64/hello-seattle/nanoserver-sac2016/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it microsoft/windowsservercore powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/amd64/hello-world/nanoserver-1709/Dockerfile
+++ b/amd64/hello-world/nanoserver-1709/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:1709
+FROM mcr.microsoft.com/windows/nanoserver:1709
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hello-world/nanoserver-1709/hello.txt
+++ b/amd64/hello-world/nanoserver-1709/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it microsoft/windowsservercore powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/amd64/hello-world/nanoserver-1803/Dockerfile
+++ b/amd64/hello-world/nanoserver-1803/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:1803
+FROM mcr.microsoft.com/windows/nanoserver:1803
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hello-world/nanoserver-1803/hello.txt
+++ b/amd64/hello-world/nanoserver-1803/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it microsoft/windowsservercore powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/amd64/hello-world/nanoserver-1809/Dockerfile
+++ b/amd64/hello-world/nanoserver-1809/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/windows/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:1809
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hello-world/nanoserver-1809/hello.txt
+++ b/amd64/hello-world/nanoserver-1809/hello.txt
@@ -5,7 +5,7 @@ This message shows that your installation appears to be working correctly.
 To generate this message, Docker took the following steps:
  1. The Docker client contacted the Docker daemon.
  2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-    (windows-amd64, nanoserver-sac2016)
+    (windows-amd64, nanoserver-1809)
  3. The Docker daemon created a new container from that image which runs the
     executable that produces the output you are currently reading.
  4. The Docker daemon streamed that output to the Docker client, which sent it

--- a/amd64/hello-world/nanoserver-sac2016/Dockerfile
+++ b/amd64/hello-world/nanoserver-sac2016/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:sac2016
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hola-mundo/nanoserver-1709/Dockerfile
+++ b/amd64/hola-mundo/nanoserver-1709/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:1709
+FROM mcr.microsoft.com/windows/nanoserver:1709
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hola-mundo/nanoserver-1709/hello.txt
+++ b/amd64/hola-mundo/nanoserver-1709/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it microsoft/windowsservercore powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/amd64/hola-mundo/nanoserver-1803/Dockerfile
+++ b/amd64/hola-mundo/nanoserver-1803/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:1803
+FROM mcr.microsoft.com/windows/nanoserver:1803
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hola-mundo/nanoserver-1803/hello.txt
+++ b/amd64/hola-mundo/nanoserver-1803/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it microsoft/windowsservercore powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/amd64/hola-mundo/nanoserver-1809/Dockerfile
+++ b/amd64/hola-mundo/nanoserver-1809/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/windows/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:1809
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hola-mundo/nanoserver-1809/hello.txt
+++ b/amd64/hola-mundo/nanoserver-1809/hello.txt
@@ -1,11 +1,11 @@
 
-Hello from Docker!
+¡Hola de DockerCon EU 2015 (Barcelona)!
 This message shows that your installation appears to be working correctly.
 
 To generate this message, Docker took the following steps:
  1. The Docker client contacted the Docker daemon.
- 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-    (windows-amd64, nanoserver-sac2016)
+ 2. The Docker daemon pulled the "hola-mundo" image from the Docker Hub.
+    (windows-amd64, nanoserver-1809)
  3. The Docker daemon created a new container from that image which runs the
     executable that produces the output you are currently reading.
  4. The Docker daemon streamed that output to the Docker client, which sent it

--- a/amd64/hola-mundo/nanoserver-sac2016/Dockerfile
+++ b/amd64/hola-mundo/nanoserver-sac2016/Dockerfile
@@ -1,3 +1,3 @@
-FROM microsoft/nanoserver:sac2016
+FROM mcr.microsoft.com/windows/nanoserver:sac2016
 COPY hello.txt C:
 CMD ["cmd", "/C", "type C:\\hello.txt"]

--- a/amd64/hola-mundo/nanoserver-sac2016/hello.txt
+++ b/amd64/hola-mundo/nanoserver-sac2016/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it microsoft/windowsservercore powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -62,7 +62,7 @@ for arch in "${arches[@]}"; do
 	EOE
 done
 
-for winVariant in nanoserver-{sac2016,1709,1803}; do
+for winVariant in nanoserver-{sac2016,1709,1803,1809}; do
 	winArches=( *"/$image/$winVariant/hello.txt" )
 	winArches=( "${winArches[@]%"/$image/$winVariant/hello.txt"}" )
 

--- a/update.sh
+++ b/update.sh
@@ -17,7 +17,7 @@ for h in */*/nanoserver-*/Dockerfile; do
 	nano="$(dirname "$h")"
 	nano="$(basename "$nano")"
 	nano="${nano#nanoserver-}"
-	sed -i 's!FROM .*!FROM microsoft/nanoserver:'"$nano"'!' "$h"
+	sed -i 's!FROM .*!FROM mcr.microsoft.com/windows/nanoserver:'"$nano"'!' "$h"
 done
 
 for h in amd64/*/hello; do


### PR DESCRIPTION
Closes #53

With https://github.com/docker-library/official-images/pull/5239 plus the Server 2019 instance I managed to get working, I think we've now managed to overcome the last of the techinical hurdles I outlined in https://github.com/docker-library/golang/pull/257#issuecomment-449772799. :+1: