### PR TITLE
Fix line endings on Windows with gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+**/*.txt  eol=lf
+Makefile  eol=lf
+hello.c   eol=lf


### PR DESCRIPTION
Fixes #78

Tested successfully in an environment where I've set `git config --global core.autocrlf true` (and thus `docker build --file Dockerfile.build https://github.com/docker-library/hello-world.git` fails), and I've confirmed that `docker build --file Dockerfile.build https://github.com/infosiftr/hello-world.git#gitattributes` succeeds.