### PR TITLE
Show matching version in sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(C_TARGETS): hello.c $(MUSL_GCC)
 			'$@' | sed \
 				-e 's/[(]$(TARGET_ARCH)[)]/(windows-$(TARGET_ARCH), '"$$winVariant"')/g' \
 				-e 's/an Ubuntu container/a Windows Server container/g' \
-				-e 's!ubuntu bash!mcr.microsoft.com/windows/servercore:ltsc2019 powershell!g' \
+				-e 's!ubuntu bash!mcr.microsoft.com/windows/servercore:'"$${winVariant##*-}"' powershell!g' \
 				-e 's![$$] docker!PS C:\\> docker!g' \
 				> "$(@D)/$$winVariant/hello.txt"; \
 		done; \

--- a/amd64/hello-world/nanoserver-1809/hello.txt
+++ b/amd64/hello-world/nanoserver-1809/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it mcr.microsoft.com/windows/servercore:ltsc2019 powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore:1809 powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/

--- a/amd64/hello-world/nanoserver-ltsc2022/hello.txt
+++ b/amd64/hello-world/nanoserver-ltsc2022/hello.txt
@@ -12,7 +12,7 @@ To generate this message, Docker took the following steps:
     to your terminal.
 
 To try something more ambitious, you can run a Windows Server container with:
- PS C:\> docker run -it mcr.microsoft.com/windows/servercore:ltsc2019 powershell
+ PS C:\> docker run -it mcr.microsoft.com/windows/servercore:ltsc2022 powershell
 
 Share images, automate workflows, and more with a free Docker ID:
  https://hub.docker.com/


### PR DESCRIPTION
The sample should also use `ltsc2022` instead of `ltsc2019` for the `ltsc2022` image