### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -5,7 +5,7 @@ RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates \
-		gnupg dirmngr \
+		gnupg \
 		wget \
 		\
 		gcc \


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu have 2.2.x 😇).