### PR TITLE
Switch to `git diff --exit-code`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
       - name: Update Binaries
         run: ./update.sh
       - name: Verify Changes
-        run: |
-          changes="$(git status --porcelain '**/hello' '**/nanoserver*/hello.txt')"
-          test -z "$changes"
+        run: git diff --exit-code
 
   generate-jobs:
     needs: verify


### PR DESCRIPTION
It might be interesting to improve this to configure `diffoscope` as a "difftool" so we can get even more useful diffs if the binaries ever change as a result, but this is at least better than the prior state (as this will give us a diff of any text files in our failing CI).